### PR TITLE
Additions and changes for version 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # ignore dev directory
 dev/
 
+# ignore minified file in demo directory
+demo/*.min.css
+
 # ignore log and tmp files
 *.log
 *.tmp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added: Property `$rawCss` to store the source CSS, enabling output of multple different minified versions of the same source without having to read the files every time.
 - Added: Property `$lastStrictness` to store the last applied strictness level, enabling the same minified source to be requested in different formats (e.g. as a string and a file) without needing to minify again.
 - Added: The minification strictness level is appended as a comment to the end of `minify()` output and is used to determine previous minification level when reading an already saved output file.
+- Changed: References, parameters and variables referring to "strictness" (`$strictness`) changed to "minification level" (`$level`).
 
 ## [1.1.1] - 22-09-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Changed: Strictness level constant names changed from `MINIFY_STRICTNESS_*` to `MINIFY_LEVEL_*`
+- Added: Strictness level 0 (none) `MINIFY_LEVEL_NONE`, which combines source files without minfication.
+- Changed: `Method::process()`/`Method::minify()` now default to `MINIFY_LEVEL_NONE` (breaking change from v1.* releases).
+
 ## [1.1.1] - 22-09-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Changed: Strictness level constant names changed from `MINIFY_STRICTNESS_*` to `MINIFY_LEVEL_*`
 - Added: Strictness level 0 (none) `MINIFY_LEVEL_NONE`, which combines source files without minfication.
 - Changed: `Method::process()`/`Method::minify()` now default to `MINIFY_LEVEL_NONE` (breaking change from v1.* releases).
+- Changed: Renamed private methods `openSourceFile()` and `saveOutputFile()` to `readFile()` and `saveFile()`.
+- Changed: Refactored `process()`
+    - Improved the way method detemines whether to read/process source files or use ssaved output.
+    - Split "save as file" and "return as string" options into separate methods (and deprecated the $noSave parameter).
+    - Method now always returns `self` to facilitate chaining output methods.
+- Added: Method `toFile()`, returns filename.
+- Added: Method `toString()`, returns minified CSS string.
+- Added: Property `$rawCss` to store the source CSS, enabling output of multple different minified versions of the same source without having to read the files every time.
+- Added: Property `$lastStrictness` to store the last applied strictness level, enabling the same minified source to be requested in different formats (e.g. as a string and a file) without needing to minify again.
+- Added: The minification strictness level is appended as a comment to the end of `minify()` output and is used to determine previous minification level when reading an already saved output file.
 
 ## [1.1.1] - 22-09-20
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Remember to remove the 'cruncher' code from the live version of your site.
 
 ## Methods
 
-### process(*$strictness, $force = false, $nosave = false*)
+### process(*$strictness = 0, $force = false, $nosave = false*)
 
 This method processes the source files, but only if the most recently modified source file time is more recent than the last output saved (modified) time (or if `$force` is `true`, see method arguments below).
 
@@ -59,7 +59,9 @@ The `process` method accepts three arguments.
 
 #### `$strictness` (*integer*) - optional
 
-There are three levels of strictness indicated by an integer (1-3):
+The levels of strictness are indicated by an integer (0-3):
+
+**`0` (None)** - combines multiple source files into one without any minification. **Default**
 
 **`1` (Low)** - only unnecessary/excess whitespace removed (blank lines, multiple spaces/tabs, empty rulesets etc).
 
@@ -67,7 +69,7 @@ There are three levels of strictness indicated by an integer (1-3):
 
 **`3` (High)** - almost zero whitespace, with only necessary whitespace remaining (e.g., between style values, such as margin declarations)
 
-If an integer other than 1-3 is provided, it will default to `3` (high).
+If an integer other than 0-3 is provided, it will default to `0` (none).
 
 #### `$force` (*boolean*) - optional
 
@@ -97,7 +99,7 @@ The CSS content string itself, not a file reference.
 
 #### `$strictness` (*integer*) - *required*
 
-The strictness level of minification (see `process()` method above). If an integer other than 1-3 is provided, it will default to `3` (high).
+The strictness level of minification (see `process()` method above). If an integer other than 0-3 is provided, it will default to `0` (none).
 
 #### Example
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ $crunch = new \lmdcode\lmdcrunchcss\LmdCrunchCss(
     ],
     '/full/path/to/css/output.min.css'
 );
-$crunch->process(3); // see Methods below for explanation of arguments
 ```
 
 **Important:** the order in which you add source files to the array will be the order in which they are added to the output file, so keep the *cascade* in mind!
@@ -37,25 +36,55 @@ $crunch->process(3); // see Methods below for explanation of arguments
 - Output file *does not need* to exist yet (it will be created if the output directory is writable).
 - The output directory path must exist (and be writable), you will need to create it manually if it does not.
 
-### 3. Use the minified CSS file
+### 3. Use the minified CSS
 
-You can link directly to the crunched/minified file in your HTML head section.
+See [Methods](#Methods) below for explanation of parameters.
+
+```php
+// Chain the methods
+$cssFile = $crunch->process(3)->toFile(); // Save output file, get filename
+
+$cssCode = $crunch->process(3)->toString(); // Get output string
+
+// Without chaining toFile/toString will operate on the same process result
+$crunch->process(3);
+
+$cssFile = $crunch->toFile();
+$cssCode = $crunch->toString();
+```
+
+Unless you are using the results in multiple places, it is easiest to just save and link to the crunched/minified file in your HTML head section.
 
 ```html
-<link href="/css/output.min.css" rel="stylesheet">
+<link href="/css/<?=$crunch->process(3)->toFile()?>" rel="stylesheet">
+```
+
+Or using the output string.
+
+```html
+<style type="text/css">
+<?=$crunch->process(3)->toString()?>
+</style>
 ```
 
 ### 4. Remove on live site
 
-Remember to remove the 'cruncher' code from the live version of your site.
+It is highly recommended that you only use this minifier in development and that you use the saved minified output file on your live site.
 
 ## Methods
 
-### process(*$strictness = 0, $force = false, $nosave = false*)
+### `process($strictness = 0, $force = false)`
 
-This method processes the source files, but only if the most recently modified source file time is more recent than the last output saved (modified) time (or if `$force` is `true`, see method arguments below).
+This method processes the source files if:
 
-The `process` method accepts three arguments.
+- No source files have been processed and no output file has been saved.
+- The most recently modified source file is fresher than the saved output file.
+- If `$strictness` is different to the last applied minification strictness level.
+- If `$force` is `true` (see method arguments below).
+
+**Returns:** self.
+
+The method accepts two arguments.
 
 #### `$strictness` (*integer*) - optional
 
@@ -73,23 +102,25 @@ If an integer other than 0-3 is provided, it will default to `0` (none).
 
 #### `$force` (*boolean*) - optional
 
-Force the recreation of the output CSS file, ignoring any modified dates. Useful for when you want to change the strictness level but haven't modified any of the source files.
+Force the recreation of minified CSS output from the source files even when it would not otherwise.
 
 Defaults to `false`.
 
-#### `$nosave` (*boolean*) - optional
+### `toFile()`
 
-Outputs the processed CSS as a string without saving it to the output file. Useful for checking output with committing to it (or for inline CSS).
+Save the minified CSS to the output file. Only saves the file if the minified source has changed.
 
-When enabling this option, you need to echo/print the results.
+When chained to the `process()` method it saves the result of that method, otherwise when called directly it saves the result of the last `process()` call.
 
-```php
-echo $crunch->process(3, false, true);
-```
+The method returns the basename (filename without path) of the output file.
 
-Defaults to `false`.
+### `toString()`
 
-### minify(*$css, $strictness*)
+Returns the minified CSS string.
+
+When chained to the `process()` method it returns the result of that method, otherwise when called directly it returns the result of the last `process()` call.
+
+### `minify($css, $strictness)`
 
 The minification method itself can be called statically, useful if you just want to crunch some inline CSS code.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ $cssFile = $crunch->toFile();
 $cssCode = $crunch->toString();
 ```
 
-Unless you are using the results in multiple places, it is easiest to just save and link to the crunched/minified file in your HTML head section.
+Unless you are using the results in multiple places, it is easiest to just save and link to the minified file in your HTML head section.
 
 ```html
 <link href="/css/<?=$crunch->process(3)->toFile()?>" rel="stylesheet">
@@ -73,22 +73,22 @@ It is highly recommended that you only use this minifier in development and that
 
 ## Methods
 
-### `process($strictness = 0, $force = false)`
+### `process($level = 0, $force = false)`
 
 This method processes the source files if:
 
 - No source files have been processed and no output file has been saved.
 - The most recently modified source file is fresher than the saved output file.
-- If `$strictness` is different to the last applied minification strictness level.
-- If `$force` is `true` (see method arguments below).
+- If `$level` is different to the last applied minification level.
+- If `$force` is `true` (see method parameters below).
 
 **Returns:** self.
 
-The method accepts two arguments.
+The method accepts two parameters.
 
-#### `$strictness` (*integer*) - optional
+#### `$level` (*integer*) - optional
 
-The levels of strictness are indicated by an integer (0-3):
+Minification levels are indicated by an integer (0-3):
 
 **`0` (None)** - combines multiple source files into one without any minification. **Default**
 
@@ -120,7 +120,7 @@ Returns the minified CSS string.
 
 When chained to the `process()` method it returns the result of that method, otherwise when called directly it returns the result of the last `process()` call.
 
-### `minify($css, $strictness)`
+### `minify($css, $level)`
 
 The minification method itself can be called statically, useful if you just want to crunch some inline CSS code.
 
@@ -128,9 +128,9 @@ The minification method itself can be called statically, useful if you just want
 
 The CSS content string itself, not a file reference.
 
-#### `$strictness` (*integer*) - *required*
+#### `$level` (*integer*) - *required*
 
-The strictness level of minification (see `process()` method above). If an integer other than 0-3 is provided, it will default to `0` (none).
+The minification level (see `process()` method above). If an integer other than 0-3 is provided, it will default to `0` (none).
 
 #### Example
 

--- a/demo/index.php
+++ b/demo/index.php
@@ -25,8 +25,8 @@ $crunch = new LmdCrunchCss($sourceFiles,  $dir . '/css-output.min.css');
 // Save output to file with default strictness (3)
 //$crunch->process();
 
-// Get returned string with minimum strictness, without saving to file
-$css = $crunch->process(1, false, true);
+// Get returned string with level 0 strictness (no minification), without saving to file
+$css = $crunch->process(0, false, true);
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -40,10 +40,15 @@ $css = $crunch->process(1, false, true);
 <div class="wrapper">
     <h1>LMD Crunch CSS Demo</h1>
 
-    <h2><code>$strictness = 1</code></h2>
-    <p><textarea id="cssout1" cols="80" rows="15"><?=$css?></textarea></p>
+    <!-- The combined output without any minification applied -->
 
-    <!-- For the next two examples, we are statically calling the minify method directly on the already partially crunched output -->
+    <h2><code>$strictness = 0</code></h2>
+    <p><textarea id="cssout0" cols="80" rows="15"><?=$css?></textarea></p>
+
+    <!-- For the following examples, we are statically calling the minify method directly on the already combined output -->
+
+    <h2><code>$strictness = 1</code></h2>
+    <p><textarea id="cssout1" cols="80" rows="15"><?=LmdCrunchCss::minify($css, 1)?></textarea></p>
 
     <h2><code>$strictness = 2</code></h2>
     <p><textarea id="cssout2" cols="80" rows="15"><?=LmdCrunchCss::minify($css, 2)?></textarea></p>

--- a/demo/index.php
+++ b/demo/index.php
@@ -22,11 +22,8 @@ $sourceFiles = [
 
 $crunch = new LmdCrunchCss($sourceFiles,  $dir . '/css-output.min.css');
 
-// Save output to file with default strictness (3)
-//$crunch->process();
-
-// Get returned string with level 0 strictness (no minification), without saving to file
-$css = $crunch->process(0, false, true);
+// Save file with maximum minification and get filename
+$cssFile = $crunch->process(3)->toFile();
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -34,27 +31,28 @@ $css = $crunch->process(0, false, true);
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>LMD Crunch CSS Demo</title>
-    <style type="text/css">.wrapper{width: 100%;max-width:800px;margin: 0 auto}p{text-align: center}textarea{width: 100%;max-width: 800px;tab-size:4;white-space: pre;overflow-wrap: normal;overflow-x: scroll}</style>
+    <style type="text/css">.wrapper{width: 100%;max-width:800px;margin: 0 auto}textarea{width: 100%;max-width: 800px;tab-size:4;white-space: pre;overflow-wrap: normal;overflow-x: scroll}</style>
 </head>
 <body>
 <div class="wrapper">
     <h1>LMD Crunch CSS Demo</h1>
 
-    <!-- The combined output without any minification applied -->
+    <h2>CSS File (set to <code>$strictness = 3</code>):</h2>
+    <p>Go to: <a href="<?=$cssFile?>"><?=$cssFile?></a></p>
+
+    <!-- String outputs with different minification levels applied -->
 
     <h2><code>$strictness = 0</code></h2>
-    <p><textarea id="cssout0" cols="80" rows="15"><?=$css?></textarea></p>
-
-    <!-- For the following examples, we are statically calling the minify method directly on the already combined output -->
+    <p><textarea id="cssout0" cols="80" rows="15"><?=$crunch->process(0)->toString()?></textarea></p>
 
     <h2><code>$strictness = 1</code></h2>
-    <p><textarea id="cssout1" cols="80" rows="15"><?=LmdCrunchCss::minify($css, 1)?></textarea></p>
+    <p><textarea id="cssout1" cols="80" rows="15"><?=$crunch->process(1)->toString()?></textarea></p>
 
     <h2><code>$strictness = 2</code></h2>
-    <p><textarea id="cssout2" cols="80" rows="15"><?=LmdCrunchCss::minify($css, 2)?></textarea></p>
+    <p><textarea id="cssout2" cols="80" rows="15"><?=$crunch->process(2)->toString()?></textarea></p>
 
     <h2><code>$strictness = 3</code></h2>
-    <p><textarea id="cssout3" cols="80" rows="5"><?=LmdCrunchCss::minify($css, 3)?></textarea></p>
+    <p><textarea id="cssout3" cols="80" rows="5"><?=$crunch->process(3)->toString()?></textarea></p>
 </div>
 </body>
 </html>

--- a/demo/index.php
+++ b/demo/index.php
@@ -37,21 +37,21 @@ $cssFile = $crunch->process(3)->toFile();
 <div class="wrapper">
     <h1>LMD Crunch CSS Demo</h1>
 
-    <h2>CSS File (set to <code>$strictness = 3</code>):</h2>
+    <h2>CSS File (set to <code>$level = 3</code>):</h2>
     <p>Go to: <a href="<?=$cssFile?>"><?=$cssFile?></a></p>
 
     <!-- String outputs with different minification levels applied -->
 
-    <h2><code>$strictness = 0</code></h2>
+    <h2><code>$level = 0</code></h2>
     <p><textarea id="cssout0" cols="80" rows="15"><?=$crunch->process(0)->toString()?></textarea></p>
 
-    <h2><code>$strictness = 1</code></h2>
+    <h2><code>$level = 1</code></h2>
     <p><textarea id="cssout1" cols="80" rows="15"><?=$crunch->process(1)->toString()?></textarea></p>
 
-    <h2><code>$strictness = 2</code></h2>
+    <h2><code>$level = 2</code></h2>
     <p><textarea id="cssout2" cols="80" rows="15"><?=$crunch->process(2)->toString()?></textarea></p>
 
-    <h2><code>$strictness = 3</code></h2>
+    <h2><code>$level = 3</code></h2>
     <p><textarea id="cssout3" cols="80" rows="5"><?=$crunch->process(3)->toString()?></textarea></p>
 </div>
 </body>


### PR DESCRIPTION
A lot of modifications and breaking changes.

Higlights:

- Added: Minification level 0 (MINIFY_LEVEL_NONE) which combines source files without minification.
- Added: Method `toFile()`, returns filename.
- Added: Method `toString()`, returns minified CSS string.
- Changed: Refactored `process()` to improved the way method detemines whether to read/process source files or use ssaved output and to split "save as file" and "return as string" options into separate methods (and deprecated the $noSave parameter).
- Changed: `Method::process()`/`Method::minify()` now default to `MINIFY_LEVEL_NONE` (breaking change from v1.* releases).