### PR TITLE
FIX: Adding/removing source files now triggers minified output file regeneration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Ignore files and folders
 .github/
+.vscode/
 dev/
 *.min.css
 *.tmp

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ The method accepts one parameter.
 
 #### `$cacheBuster` *&lt;boolean&gt;* - *optional*
 
-Add a cache buster (a timestsamp) to the markup. Defaults to false.
+Add a cache buster (a timestamp) to the markup. Defaults to false.
 
 #### Example 4.1: `$devMode` not enabled (default)
 

--- a/demo/demo.phps
+++ b/demo/demo.phps
@@ -18,7 +18,9 @@
  */
 
 use lmdcode\lmdcrunchcss\LmdCrunchCss;
+
 include '../src/LmdCrunchCss.php';
+
 $dirPath = '/' . trim(str_replace('\\', '/', dirname($_SERVER['PHP_SELF'])), '/');
 $sourceFiles = [$dirPath . '/input-1.css', $dirPath . '/input-2.css', $dirPath . '/input-3.css',];
 $minifiedFile = $dirPath . '/output.min.css';
@@ -31,7 +33,7 @@ $css = $crunch->process(LmdCrunchCss::MINIFY_NONE)->toString(); // just need the
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>LMD Crunch CSS Demo</title>
-    <style type="text/css"><?php // Minfiy actual CSS for this demo page inline
+    <style type="text/css"><?php // Minify actual CSS for this demo page inline
 echo LmdCrunchCss::minify(
     "html, *, ::before, ::after {
         box-sizing: border-box;

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>LMD Crunch CSS Demo</title>
-    <style type="text/css">html,*,::before,::after{box-sizing:border-box}html{line-height:1.4;font-size:16px;font-size-adjust:0.5;font-weight:400;text-size-adjust:none}body{background-color:#fff;color:#000;font-size:1rem}header,main,footer{width:100%;max-width:800px;margin:0 auto}header{display:flex;flex-direction:row;flex-wrap:wrap;justify-content:space-between;align-content:center;align-items:center}header > h1{flex:1;margin:0;padding:0;font-size:1.5rem}header > a{color:#990000;text-decoration:none}#gh{flex:0 0 100px;width:100px;display:flex;flex-direction:row;flex-wrap:wrap;justify-content:space-between;align-content:center;align-items:center;gap:0 0.5rem;font-size:0.75rem;line-height:1}#gh > svg{flex:0 0 32px;width:32px;height:32px}#gh > span{flex:1;line-height:1.2}footer{text-align:center}p{margin:1rem 0}textarea{width:100%;max-width:800px;tab-size:4;white-space:pre;overflow-wrap:normal;overflow-x:auto}@media screen and (min-width:640px){body{font-size:1.125rem}header > h1{font-size:2rem}}/*lmdcrunchcss=3*/</style>
+    <style type="text/css">html,*,::before,::after{box-sizing:border-box}html{line-height:1.4;font-size:16px;font-size-adjust:0.5;font-weight:400;text-size-adjust:none}body{background-color:#fff;color:#000;font-size:1rem}header,main,footer{width:100%;max-width:800px;margin:0 auto}header{display:flex;flex-direction:row;flex-wrap:wrap;justify-content:space-between;align-content:center;align-items:center}header > h1{flex:1;margin:0;padding:0;font-size:1.5rem}header > a{color:#990000;text-decoration:none}#gh{flex:0 0 100px;width:100px;display:flex;flex-direction:row;flex-wrap:wrap;justify-content:space-between;align-content:center;align-items:center;gap:0 0.5rem;font-size:0.75rem;line-height:1}#gh > svg{flex:0 0 32px;width:32px;height:32px}#gh > span{flex:1;line-height:1.2}footer{text-align:center}p{margin:1rem 0}textarea{width:100%;max-width:800px;tab-size:4;white-space:pre;overflow-wrap:normal;overflow-x:auto}@media screen and (min-width:640px){body{font-size:1.125rem}header > h1{font-size:2rem}}</style>
 </head>
 <body>
 <header>
@@ -31,11 +31,11 @@ html,
 
 html
 {
-	line-height: 1.4;
-	font-size: 16px;
-	font-size-adjust: 0.5;
-	font-weight: 400;
-	text-size-adjust: none;
+    line-height: 1.4;
+    font-size: 16px;
+    font-size-adjust: 0.5;
+    font-weight: 400;
+    text-size-adjust: none;
 }
 
 body
@@ -109,10 +109,10 @@ a:visited
 /** CSS Input 3 */
 @media screen and (min-width: 640px)
 {
-	body
+    body
     {
-		font-size: 1.125rem;
-	}
+        font-size: 1.125rem;
+    }
     
     .container
     {
@@ -130,80 +130,79 @@ a:visited
         margin: 0;
     }
 }
-/*lmdcrunchcss=0*/</textarea></p>
+/*lmdcrunchcss=0;09fc4ea906e5913f1e1152f3baf75ba2*/</textarea></p>
 
     <h2><label for="cssout1"><code>MINIFY_LEVEL_LOW (1)</code></label></h2>
     <p><textarea id="cssout1" cols="80" rows="15">html, *, ::before, ::after {
-	box-sizing: border-box;
+    box-sizing: border-box;
 }
 html {
-	line-height: 1.4;
-	font-size: 16px;
-	font-size-adjust: 0.5;
-	font-weight: 400;
-	text-size-adjust: none;
+    line-height: 1.4;
+    font-size: 16px;
+    font-size-adjust: 0.5;
+    font-weight: 400;
+    text-size-adjust: none;
 }
 body {
-	background-color: #fff;
-	color: #000;
-	font-size: 1rem;
+    background-color: #fff;
+    color: #000;
+    font-size: 1rem;
 }
 header, footer {
-	text-align: center;
+    text-align: center;
 }
 main {
-	width: 100%;
-	max-width: 800px;
-	margin: 0 auto;
+    width: 100%;
+    max-width: 800px;
+    margin: 0 auto;
 }
 h1 {
-	margin: 1rem 0 0.5rem 0;
-	font-size: 2em;
+    margin: 1rem 0 0.5rem 0;
+    font-size: 2em;
 }
 p {
-	margin: 1rem 0;
+    margin: 1rem 0;
 }
 .container {
-	width: 100%;
-	margin: 1rem 0;
+    width: 100%;
+    margin: 1rem 0;
 }
 .item {
-	margin: 1rem auto;
+    margin: 1rem auto;
 }
 a {
-	color: #00f;
+    color: #00f;
 }
 a:hover, a:focus {
-	color: #f0f;
+    color: #f0f;
 }
 a:active {
-	color: #f00;
+    color: #f00;
 }
 a:visited {
-	color: rgb(109, 109, 255);
+    color: rgb(109, 109, 255);
 }
 .highlight {
-	background-color: #ffff66;
+    background-color: #ffff66;
 }
 @media screen and (min-width: 640px) {
-	body {
-		font-size: 1.125rem;
-	}
-	.container {
-		display: flex;
-		flex-direction: row;
-		flex-wrap: nowrap;
-		justify-content: flex-start;
-		align-items: flex-start;
-		align-content: flex-start;
-		gap: 0 2rem;
-	}
-	.item {
-		flex: 0 0 50%;
-		margin: 0;
-	}
-}
-/*lmdcrunchcss=1*/</textarea></p>
+    body {
+        font-size: 1.125rem;
+    }
+    .container {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: nowrap;
+        justify-content: flex-start;
+        align-items: flex-start;
+        align-content: flex-start;
+        gap: 0 2rem;
+    }
+    .item {
+        flex: 0 0 50%;
+        margin: 0;
+    }
+}</textarea></p>
 
     <h2><label for="cssout2"><code>MINIFY_LEVEL_MEDIUM (2)</code></label></h2>
     <p><textarea id="cssout2" cols="80" rows="15">html,*,::before,::after{box-sizing:border-box}
@@ -221,14 +220,13 @@ a:active{color:#f00}
 a:visited{color:rgb(109,109,255)}
 .highlight{background-color:#ffff66}
 @media screen and (min-width:640px){
-	body{font-size:1.125rem}
-	.container{display:flex;flex-direction:row;flex-wrap:nowrap;justify-content:flex-start;align-items:flex-start;align-content:flex-start;gap:0 2rem}
-	.item{flex:0 0 50%;margin:0}
-}
-/*lmdcrunchcss=2*/</textarea></p>
+    body{font-size:1.125rem}
+    .container{display:flex;flex-direction:row;flex-wrap:nowrap;justify-content:flex-start;align-items:flex-start;align-content:flex-start;gap:0 2rem}
+    .item{flex:0 0 50%;margin:0}
+}</textarea></p>
 
     <h2><label for="cssout3"><code>MINIFY_LEVEL_HIGH (3)</code></label></h2>
-    <p><textarea id="cssout3" cols="80" rows="3">html,*,::before,::after{box-sizing:border-box}html{line-height:1.4;font-size:16px;font-size-adjust:0.5;font-weight:400;text-size-adjust:none}body{background-color:#fff;color:#000;font-size:1rem}header,footer{text-align:center}main{width:100%;max-width:800px;margin:0 auto}h1{margin:1rem 0 0.5rem 0;font-size:2em}p{margin:1rem 0}.container{width:100%;margin:1rem 0}.item{margin:1rem auto}a{color:#00f}a:hover,a:focus{color:#f0f}a:active{color:#f00}a:visited{color:rgb(109,109,255)}.highlight{background-color:#ffff66}@media screen and (min-width:640px){body{font-size:1.125rem}.container{display:flex;flex-direction:row;flex-wrap:nowrap;justify-content:flex-start;align-items:flex-start;align-content:flex-start;gap:0 2rem}.item{flex:0 0 50%;margin:0}}/*lmdcrunchcss=3*/</textarea></p>
+    <p><textarea id="cssout3" cols="80" rows="3">html,*,::before,::after{box-sizing:border-box}html{line-height:1.4;font-size:16px;font-size-adjust:0.5;font-weight:400;text-size-adjust:none}body{background-color:#fff;color:#000;font-size:1rem}header,footer{text-align:center}main{width:100%;max-width:800px;margin:0 auto}h1{margin:1rem 0 0.5rem 0;font-size:2em}p{margin:1rem 0}.container{width:100%;margin:1rem 0}.item{margin:1rem auto}a{color:#00f}a:hover,a:focus{color:#f0f}a:active{color:#f00}a:visited{color:rgb(109,109,255)}.highlight{background-color:#ffff66}@media screen and (min-width:640px){body{font-size:1.125rem}.container{display:flex;flex-direction:row;flex-wrap:nowrap;justify-content:flex-start;align-items:flex-start;align-content:flex-start;gap:0 2rem}.item{flex:0 0 50%;margin:0}}</textarea></p>
 </main>
 <footer>
     <p>

--- a/src/LmdCrunchCss.php
+++ b/src/LmdCrunchCss.php
@@ -5,7 +5,7 @@
  * (c) LMD, 2022
  * https://github.com/lmd-code/lmdcrunchcss
  *
- * @version 3.0.1
+ * @version 3.0.2
  * @license MIT
  */
 
@@ -116,10 +116,16 @@ class LmdCrunchCss
     private $lastMinify = -1; // -1 if not yet applied to allow for level 0
 
     /**
+     * The last hash of all input and output files
+     * @var string
+     */
+    private $lastFileHash = ''; // md5 of file paths
+
+    /**
      * Minification level string token added to CSS files
      * @var string
      */
-    private static $minifyToken = '/*lmdcrunchcss=%d*/';
+    private static $minifyToken = '/*lmdcrunchcss=%d;%s*/';
 
     /**
      * Valid mime-types for CSS files
@@ -292,6 +298,7 @@ class LmdCrunchCss
      * Only processes files if:
      * - No source files have been processed and no output file has been saved.
      * - The most recently modified source file is fresher than the saved output file.
+     * - The file hash of input/output files has changed (by adding, removing, renaming files).
      * - If `$level` is different to the last applied minification level.
      * - If `$force` is `true`.
      *
@@ -317,20 +324,31 @@ class LmdCrunchCss
                 $level = self::MINIFY_NONE; // default
             }
 
-            // Get output CSS content if it exists and is more recent than the source files.
+            $staleOutput = ($this->outLastModified < $this->srcLastModified);
+            $fileHash = md5(implode('', $this->srcFiles) . $this->outFile);
+
+            // Get output CSS content if it exists.
             // We do this here instead of in the constructor method in case a file is saved
             // before a call to process() -- e.g. for output at different minification levels.
-            if ($this->outFileExists && $this->outLastModified > $this->srcLastModified) {
+            if ($this->outFileExists) {
                 $this->outCss = $this->readFile($this->outFile);
                 // Get minification level from file (last line comment)
-                $regex = str_replace('%d', '(?<level>\d)', preg_quote(self::$minifyToken, '/'));
+                $regex = str_replace(
+                    '%d;%s',
+                    '(?<level>\d);(?<chksum>[a-z0-9]*)',
+                    preg_quote(self::$minifyToken, '/')
+                );
                 if (preg_match('/' . $regex . '/', $this->outCss, $match) === 1) {
                     $this->lastMinify = intval($match['level']);
+                    $this->lastFileHash = strval($match['chksum']);
                 }
             }
 
             // Determine whether to run the minification process
-            if ($force || $this->outCss === '' || $level !== $this->lastMinify) {
+            if (
+                $force || $this->outCss === '' || $staleOutput || $level !== $this->lastMinify
+                || $fileHash !== $this->lastFileHash
+            ) {
                 // We only need to read the source files if we haven't already done so
                 if ($this->rawCss === '') {
                     $combinedCSS = "";
@@ -341,12 +359,13 @@ class LmdCrunchCss
                     $this->rawCss = $combinedCSS;
                 }
 
-                $this->outCss = self::minify($this->rawCss, $level);
+                $this->outCss = self::minify($this->rawCss, $level, $fileHash);
                 $this->updatedCss = true;
             }
         }
 
         $this->lastMinify = $level;
+        $this->lastFileHash = $fileHash;
 
         return $this;
     }
@@ -462,12 +481,13 @@ class LmdCrunchCss
     /**
      * Minify CSS source
      *
-     * @param string $css   CSS source to minify
-     * @param int    $level Minification level  (@see `process()` method)
+     * @param string $css       CSS source to minify
+     * @param int    $level     Minification level  (@see `process()` method)
+     * @param string $fileHash  Hash of all input and output file paths (@see `process()` method)
      *
      * @return string
      */
-    public static function minify(string $css, int $level): string
+    public static function minify(string $css, int $level, string $fileHash = ''): string
     {
         if (($css = trim($css)) === '') {
             return ''; // no CSS was provided
@@ -478,7 +498,7 @@ class LmdCrunchCss
             filter_var($level, FILTER_VALIDATE_INT, self::$filterOpts) === false
             || $level === self::MINIFY_NONE
         ) {
-            return $css . "\n" . sprintf(self::$minifyToken, self::MINIFY_NONE);
+            return $css . "\n" . sprintf(self::$minifyToken, self::MINIFY_NONE, $fileHash);
         }
 
         // Variable length space character - only include when $level is low
@@ -573,8 +593,8 @@ class LmdCrunchCss
             $css .= ($level < self::MINIFY_HIGH) ? "\n" : "";
         }
 
-        // Append minification level (is used to identify level when output file is read)
-        $css .= sprintf(self::$minifyToken, $level);
+        // Append minification level and file hash (used to identify changes when processed again)
+        $css .= sprintf(self::$minifyToken, $level, $fileHash);
 
         return trim($css);
     }

--- a/src/LmdCrunchCss.php
+++ b/src/LmdCrunchCss.php
@@ -44,7 +44,7 @@ class LmdCrunchCss
     public const MINIFY_HIGH = 3;
 
     /**
-     * An error occured
+     * An error occurred
      * @var boolean
      */
     private $hasError = false;
@@ -92,7 +92,7 @@ class LmdCrunchCss
     private $outLastModified = 0;
 
     /**
-     * Raw/unminfied CSS from combined source files
+     * Raw/unminified CSS from combined source files
      * @var string
      */
     private $rawCss = '';
@@ -335,12 +335,12 @@ class LmdCrunchCss
                 // Get minification level and file hash from file (last line comment)
                 $regex = str_replace(
                     '%d;%s',
-                    '(?<level>\d);(?<chksum>[a-z0-9]*)',
+                    '(?<level>\d);(?<fhash>[a-z0-9]*)',
                     preg_quote(self::$minifyToken, '/')
                 );
                 if (preg_match('/' . $regex . '/', $this->outCss, $match) === 1) {
                     $this->lastMinify = intval($match['level']);
-                    $this->lastFileHash = strval($match['chksum']);
+                    $this->lastFileHash = strval($match['fhash']);
                 }
             }
 


### PR DESCRIPTION
**Fixes Issue**

Minified output was not being regenerated when a source file was removed from the list, or when a new source file was added that had a modification date earlier than the output file's.

**Summary of Changes:**

- Adding/removing source files now triggers minified output file regeneration by adding a file hash to the output file comment token along with the minification level. Files using the old token will be reminified.
- Small refactor: Removed application of the comment token from the `minify()` method and added it to the `process()` method. This means that the `minify()` method will no longer append the comment when used independantly on CSS strings (where it is not needed anyway).
- Fixed some typos.

@lmd-code
